### PR TITLE
Add CNAME for muxfm.js.org

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+muxfm.js.org


### PR DESCRIPTION
This PR adds a CNAME for the domain "muxfm.js.org". I'll merge it as soon as js.org merges their PR.

js.org PR: https://github.com/js-org/js.org/pull/4102